### PR TITLE
Update for podman 5.0 (along with other miscellaneous changes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,11 @@ Then the `.container` files are translated into systemd units that create the co
 Note how the `immich-server.container` have an install target on `default.target` which makes it start on boot. 
 I am not sure the `multi-user` target is really needed. 
 
-# How do I deploy it ? 
+# How do I deploy it ?
+
+Rename `env.example` to `immich.env`.
+
+## rootful podman
 
 Copy theses files into `/etc/containers/systemd` then reload systemd. 
 
@@ -23,8 +27,50 @@ sudo cp -r . /etc/containers/systemd/immich
 sudo systemctl daemon-reload
 ```
 
+## rootless podman
+
+Create a user that will run immich containers.
+The containers will act as this user on the host:
+- This user will be used when enforcing file permissions in the mounted volumes.
+- When immich creates files in the mounted volumes, they will be owned by this user on the host.
+
+```
+useradd -r -m -d /var/lib/immich immich
+```
+The containers and named volumes will be stored in `/var/lib/immich`.
+
+Configure `subuid` and `subgid` for podman to be able to run as this user:
+```
+# cat >> /etc/subuid <<EOF
+immich:2000000:1000000
+EOF
+# cat >> /etc/subgid <<EOF
+immich:2000000:1000000
+EOF
+```
+
+Copy these files into the user's `containers/systemd` directory:
+```
+# sudo -u immich mkdir -p ~immich/.config/containers/systemd/immich
+# sudo -u immich cp -v *.image *.container *.pod immich.env ~immich/.config/containers/systemd/immich/
+```
+
+Start the user session, make it persistent and start the pod (replace 998 with `immich` user ID):
+```
+# systemctl start user@998
+# loginctl enable-linger immich
+# systemctl --user -M immich@.host start immich-pod.service
+```
+
+Watch `journalctl` to see if the containers start successfully -
+the first start can fail if downloading the images takes more than the default startup timeout:
+```
+# journalctl -f
+```
+
+The containers should start on the next boot automatically.
+
 
 # TODO 
-- Delete the pod workaround once podman 5 is available (should be very soon)
 - write a makefile or a justfile that insert the variables in the unit files maybe ? Right now it requires some copy and pasting.
-- Contribute it upstream to immich (mainly waiting on podman 5)
+- Contribute it upstream to immich

--- a/env-example.env
+++ b/env-example.env
@@ -1,8 +1,5 @@
 # You can find documentation for all the supported env variables at https://immich.app/docs/install/environment-variables
 
-# The location where your uploaded files are stored
-UPLOAD_LOCATION=./path/to/your/local/library/upload/target/
-
 # Connection secret for postgres. You should change it to a random password. 
 # The two values should match
 DB_PASSWORD=postgres

--- a/env-example.env
+++ b/env-example.env
@@ -3,9 +3,6 @@
 # The location where your uploaded files are stored
 UPLOAD_LOCATION=./path/to/your/local/library/upload/target/
 
-# The Immich version to use. You can pin this to a specific version like "v1.71.0"
-IMMICH_VERSION=v1.94.1
-
 # Connection secret for postgres. You should change it to a random password. 
 # The two values should match
 DB_PASSWORD=postgres

--- a/env-example.env
+++ b/env-example.env
@@ -22,3 +22,5 @@ DB_DATABASE_NAME=immich
 POSTGRES_DB=immich
 
 REDIS_HOSTNAME=immich_redis
+
+IMMICH_MACHINE_LEARNING_URL=http://immich_machine_learning:3003

--- a/immich-database.container
+++ b/immich-database.container
@@ -1,7 +1,5 @@
 [Container]
-# FIXME: this requires podman 5.0
-#Pod=immich.pod
-PodmanArgs=--pod immich
+Pod=immich.pod
 ContainerName=immich_postgres
 EnvironmentFile=/etc/containers/systemd/immich/immich.env
 Image=docker.io/tensorchord/pgvecto-rs:pg14-v0.2.0@sha256:90724186f0a3517cf6914295b5ab410db9ce23190a2d9d0b9dd6463e3fa298f0

--- a/immich-database.container
+++ b/immich-database.container
@@ -1,7 +1,7 @@
 [Container]
 Pod=immich.pod
 ContainerName=immich_postgres
-EnvironmentFile=/etc/containers/systemd/immich/immich.env
+EnvironmentFile=immich.env
 Image=docker.io/tensorchord/pgvecto-rs:pg14-v0.2.0@sha256:90724186f0a3517cf6914295b5ab410db9ce23190a2d9d0b9dd6463e3fa298f0
 Volume=pgdata:/var/lib/postgresql/data
 

--- a/immich-machine-learning.container
+++ b/immich-machine-learning.container
@@ -1,7 +1,5 @@
 [Container]
-# FIXME: this requires podman 5.0
-#Pod=immich.pod
-PodmanArgs=--pod immich
+Pod=immich.pod
 ContainerName=immich_machine_learning
 EnvironmentFile=/etc/containers/systemd/immich/immich.env
 Image=ghcr.io/immich-app/immich-machine-learning:release

--- a/immich-machine-learning.container
+++ b/immich-machine-learning.container
@@ -1,8 +1,8 @@
 [Container]
 Pod=immich.pod
 ContainerName=immich_machine_learning
-EnvironmentFile=/etc/containers/systemd/immich/immich.env
 Image=ghcr.io/immich-app/immich-machine-learning:release
+EnvironmentFile=immich.env
 Volume=model-cache:/cache
 
 [Service]

--- a/immich-machine-learning.container
+++ b/immich-machine-learning.container
@@ -1,8 +1,8 @@
 [Container]
 Pod=immich.pod
 ContainerName=immich_machine_learning
-Image=ghcr.io/immich-app/immich-machine-learning:release
 EnvironmentFile=immich.env
+Image=ghcr.io/immich-app/immich-machine-learning:v1.101.0
 Volume=model-cache:/cache
 
 [Service]

--- a/immich-microservices.container
+++ b/immich-microservices.container
@@ -3,9 +3,7 @@ Requires=immich-redis.service immich-database.service
 After=immich-redis.service immich-database.service
 
 [Container]
-# FIXME: this requires podman 5.0
-#Pod=immich.pod
-PodmanArgs=--pod immich
+Pod=immich.pod
 ContainerName=immich_microservices
 EnvironmentFile=/etc/containers/systemd/immich/immich.env
 Exec=start.sh microservices

--- a/immich-microservices.container
+++ b/immich-microservices.container
@@ -5,7 +5,7 @@ After=immich-redis.service immich-database.service
 [Container]
 Pod=immich.pod
 ContainerName=immich_microservices
-EnvironmentFile=/etc/containers/systemd/immich/immich.env
+EnvironmentFile=immich.env
 Exec=start.sh microservices
 Image=immich-server.image
 Volume=/home/raid/immich:/usr/src/app/upload:z

--- a/immich-redis.container
+++ b/immich-redis.container
@@ -1,7 +1,7 @@
 [Container]
 Pod=immich.pod
 ContainerName=immich_redis
-Image=docker.io/redis:6.2-alpine@sha256:afb290a0a0d0b2bd7537b62ebff1eb84d045c757c1c31ca2ca48c79536c0de82
+Image=docker.io/redis:6.2-alpine@sha256:51d6c56749a4243096327e3fb964a48ed92254357108449cb6e23999c37773c5
 
 [Service]
 Restart=always

--- a/immich-redis.container
+++ b/immich-redis.container
@@ -1,7 +1,5 @@
 [Container]
-# FIXME: this requires podman 5.0
-#Pod=immich.pod
-PodmanArgs=--pod immich
+Pod=immich.pod
 ContainerName=immich_redis
 Image=docker.io/redis:6.2-alpine@sha256:afb290a0a0d0b2bd7537b62ebff1eb84d045c757c1c31ca2ca48c79536c0de82
 

--- a/immich-server.container
+++ b/immich-server.container
@@ -3,14 +3,11 @@ Requires=immich-redis.service immich-database.service immich-microservices.servi
 After=immich-redis.service immich-database.service immich-microservices.service immich-database.service immich-machine-learning.service
 
 [Container]
-# FIXME: this requires podman 5.0
-#Pod=immich.pod
-PodmanArgs=--pod immich
+Pod=immich.pod
 ContainerName=immich_server
 EnvironmentFile=/etc/containers/systemd/immich/immich.env
 Exec=start.sh immich
 Image=immich-server.image
-#PublishPort=2283:3001
 Volume=/home/raid/immich:/usr/src/app/upload:z
 Volume=/etc/localtime:/etc/localtime:ro
 
@@ -18,4 +15,4 @@ Volume=/etc/localtime:/etc/localtime:ro
 Restart=always
 
 [Install]
-WantedBy=multi-user.target default.target
+WantedBy=default.target

--- a/immich-server.container
+++ b/immich-server.container
@@ -5,7 +5,7 @@ After=immich-redis.service immich-database.service immich-microservices.service 
 [Container]
 Pod=immich.pod
 ContainerName=immich_server
-EnvironmentFile=/etc/containers/systemd/immich/immich.env
+EnvironmentFile=immich.env
 Exec=start.sh immich
 Image=immich-server.image
 Volume=/home/raid/immich:/usr/src/app/upload:z

--- a/immich-server.image
+++ b/immich-server.image
@@ -3,4 +3,4 @@ Wants=network-online.target nss-lookup.target
 After=network-online.target nss-lookup.target
 
 [Image]
-Image=ghcr.io/immich-app/immich-server:v1.98.1
+Image=ghcr.io/immich-app/immich-server:v1.101.0

--- a/immich-server.image
+++ b/immich-server.image
@@ -2,15 +2,5 @@
 Wants=network-online.target nss-lookup.target
 After=network-online.target nss-lookup.target
 
-#FIXME  workaround unit we can use the Pod unit
-Before=immich-database.service immich-redis.service immich-machine-learning.service
-RequiredBy=immich-database.service immich-redis.service immich-machine-learning.service
-
 [Image]
 Image=ghcr.io/immich-app/immich-server:v1.98.1
-
-# workaround until podman 5 is released then the .pod
-# unit file will do that
-[Service]
-ExecStartPre=podman pod rm --force immich
-ExecStartPost=podman pod create --publish 2283:3001 immich


### PR DESCRIPTION
Podman 5.0 is out, so the workarounds can be removed.
This works for me on Podman 5.0.0 on Gentoo when placed into its own (`immich`) user's  `~/.config/containers/systemd/immich` and enabled with:
```
# cat >> /etc/subuid <<EOF
immich:2000000:1000000
EOF
# cat >> /etc/subgid <<EOF
immich:2000000:1000000
EOF
# systemctl start user@998
# loginctl enable-linger immich
# systemctl --user -M immich@.host start immich-pod.service
```

- Use the `pod` unit directly.
- Remove custom commands from the `image` unit.
- Remove `WantedBy=multi-user.target` from `immich-server.container` - just `WantedBy=default.target` is enough.
- Add `IMMICH_MACHINE_LEARNING_URL` to the environment - otherwise, `immich_microservices` tries to access it via `immich-machine-learning` (which is not the container name) and fails.
- Use a relative path to `immich.env` to make it work with the unit files in any location (e.g. `/etc/containers/systemd` and `~/.config/containers/systemd`).
- Remove unused environment variables (although it would be better to start using them instead).
- Update image versions for Immich v1.101.0.