### PR TITLE
Fix server exec command for 1.106+

### DIFF
--- a/immich-machine-learning.container
+++ b/immich-machine-learning.container
@@ -2,7 +2,7 @@
 Pod=immich.pod
 ContainerName=immich_machine_learning
 EnvironmentFile=immich.env
-Image=ghcr.io/immich-app/immich-machine-learning:v1.101.0
+Image=ghcr.io/immich-app/immich-machine-learning:v1.108.0
 Volume=model-cache:/cache
 HealthCmd=["/bin/bash", "-c", "exec 5<>/dev/tcp/127.0.0.1/3003"]
 HealthStartPeriod=30s

--- a/immich-server.container
+++ b/immich-server.container
@@ -6,7 +6,6 @@ After=immich-redis.service immich-database.service
 Pod=immich.pod
 ContainerName=immich_server
 EnvironmentFile=immich.env
-Exec=start.sh immich
 Image=immich-server.image
 Volume=/path/to/immich/library:/usr/src/app/upload:z
 


### PR DESCRIPTION
- immich-server: Update exec command for 1.106+

    A breaking change in 1.106 requires a removal
    of the explicit container exec command:
    https://github.com/immich-app/immich/discussions/10942#discussioncomment-9978890

    This is easy to see in the release notes on the web:
    https://github.com/immich-app/immich/releases/tag/v1.106.1
    but hard to see in the release notification email -
    the diff is not colorized.
- immich-machine-learning: Update version to 1.108.0

    to match the server version.