### PR TITLE
Isolate containers from net, use proxy for access

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ This setup consist in:
  - `immich.pod` file defining a pod that will host all the containers.
  - `immich-server.image` defining the immich version.
  - several `immich-*.container` files defining the containers, volumes etc..
+ - Systemd activation socket, `immich-proxy.socket`, this provides a way to access immich from
+   outside the pod. Otherwise all the containers in this setup have no network access.
  
 The `.container` files are translated into systemd units that create the containers. 
 
@@ -25,11 +27,13 @@ Rename `env.example` to `immich.env`. Populate the values as needed.
 
 ## rootful podman
 
-Copy theses files into `/etc/containers/systemd` then reload systemd. 
+Copy theses files into `/etc/containers/systemd` then reload systemd. Copy the .socket file to
+`/etc/systemd/system`.
 
 It can be a subdirectory. e.g : 
 ```
 sudo cp -r . /etc/containers/systemd/immich
+sudo cp immich-proxy.socket /etc/systemd/system
 sudo systemctl daemon-reload
 ```
 
@@ -56,10 +60,15 @@ immich:2000000:1000000
 EOF
 ```
 
-Copy these files into the user's `containers/systemd` directory:
+Copy immich-proxy.socket to `~immich/.config/systemd/user`.
+
+Copy the remaining files into the user's `containers/systemd` directory:
+
 ```
 sudo -u immich mkdir -p ~immich/.config/containers/systemd/immich
 sudo -u immich cp -v *.image *.container *.pod immich.env ~immich/.config/containers/systemd/immich/
+sudo -u immich mkdir -p ~immich/.config/systemd/user
+sudo -u immich cp -v *.image *.socket ~immich/.config/systemd/user/
 ```
 
 Start the user session, make it persistent and start the pod:

--- a/env-example.env
+++ b/env-example.env
@@ -8,13 +8,13 @@ POSTGRES_PASSWORD=postgres
 # The values below this line do not need to be changed
 ###################################################################################
 
-DB_HOSTNAME=immich_postgres
+DB_HOSTNAME=127.0.0.1
 DB_USERNAME=postgres
 POSTGRES_USER=postgres
 
 DB_DATABASE_NAME=immich
 POSTGRES_DB=immich
 
-REDIS_HOSTNAME=immich_redis
+REDIS_HOSTNAME=127.0.0.1
 
-IMMICH_MACHINE_LEARNING_URL=http://immich_machine_learning:3003
+IMMICH_MACHINE_LEARNING_URL=http://127.0.0.1:3003

--- a/immich-proxy.container
+++ b/immich-proxy.container
@@ -8,9 +8,7 @@ ContainerName=immich_proxy
 # Alpine image has the stream proxy function: https://stackoverflow.com/questions/41696177/how-to-get-nginx-with-stream-ssl-module-without-recompiling-docker-accepted
 Image=docker.io/nginx:1.27.0-alpine
 Environment=NGINX=4;3;
-Volume=%h/immich/nginx.conf:/etc/nginx/nginx.conf:ro
-Volume=%h/ssl-certs:/ssl:ro
-Volume=%h/immich/photo-frame:/data/photo-frame:ro
+Volume=nginx.conf:/etc/nginx/nginx.conf:ro
 
 [Install]
 WantedBy=default.target

--- a/immich-proxy.container
+++ b/immich-proxy.container
@@ -1,0 +1,16 @@
+[Unit]
+Requires=immich-proxy.socket immich-server.service
+After=immich-proxy.socket immich-server.service
+
+[Container]
+Pod=immich.pod
+ContainerName=immich_proxy
+# Alpine image has the stream proxy function: https://stackoverflow.com/questions/41696177/how-to-get-nginx-with-stream-ssl-module-without-recompiling-docker-accepted
+Image=docker.io/nginx:1.27.0-alpine
+Environment=NGINX=4;3;
+Volume=%h/immich/nginx.conf:/etc/nginx/nginx.conf:ro
+Volume=%h/ssl-certs:/ssl:ro
+Volume=%h/immich/photo-frame:/data/photo-frame:ro
+
+[Install]
+WantedBy=default.target

--- a/immich-proxy.socket
+++ b/immich-proxy.socket
@@ -1,0 +1,12 @@
+[Unit]
+Description=immich external access proxy sockets
+
+[Socket]
+# Immich web
+ListenStream=0.0.0.0:2283
+# Postgres db for backups
+ListenStream=127.0.0.1:5433
+Service=immich-proxy.service
+
+[Install]
+WantedBy=sockets.target

--- a/immich.pod
+++ b/immich.pod
@@ -1,3 +1,3 @@
 [Pod]
 PodName=immich
-PublishPort=2283:3001
+Network=none

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,47 @@
+worker_processes  1;
+events {
+    worker_connections  1024;
+}
+http {
+  server {
+    server_name immich;
+    listen 2283;
+
+    # allow large file uploads
+    client_max_body_size 50000M;
+
+    # Set headers
+    proxy_set_header Host              $http_host;
+    proxy_set_header X-Real-IP         $remote_addr;
+    proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+
+    # enable websockets: http://nginx.org/en/docs/http/websocket.html
+    proxy_http_version 1.1;
+    proxy_set_header   Upgrade    $http_upgrade;
+    proxy_set_header   Connection "upgrade";
+    proxy_redirect     off;
+
+    # set timeout
+    proxy_read_timeout 600s;
+    proxy_send_timeout 600s;
+    send_timeout       600s;
+
+    location / {
+      proxy_pass http://127.0.0.1:3001/;
+    }
+  }
+}
+
+stream {
+  server {
+    # nginx seems to insist on re-binding an inherited socket, so we have to use the exact same
+    # address and can't use a port that is already bound to in the container.
+    listen 127.0.0.1:5433;
+    proxy_pass backend;
+  }
+
+  upstream backend {
+    server 127.0.0.1:5432;
+  }
+}


### PR DESCRIPTION
The idea is to disallow outside access from any of the immich containers.
This won't work if you're running e.g. the ML container on a
separate machine.

This adds a new proxy container that runs nginx to provide access from
outside to the immich web port and the postgres db port (for backups).
Then we set the pod network to "none" meaning that containers in the pod
only have the loopback interfaces. They can talk to each other, but not
to the outside world.

The outside world can access it through a systemd socket and the proxy.