### PR TITLE
Make README hyperlink point to correct URL for text

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # immich-app podman + quadlet deployment
 
-⚠️ **Curently supported immich version: [v1.126.1](https://github.com/immich-app/immich/releases/tag/v1.118.1)** ⚠️
+⚠️ **Curently supported immich version: [v1.126.1](https://github.com/immich-app/immich/releases/tag/v1.126.1)** ⚠️
 
 
 This is a set of unit files to deploy immich through the podman-quadlet systemd generator


### PR DESCRIPTION
- Hyperlink was still pointing to v1.118.1 while text has already been updated to v1.126.1; updated hyperlink to match text version.