### PR TITLE
Use podman secret for the database password

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,13 @@ Note how the `immich-server.container` has an install target on `default.target`
 
 # How do I deploy it ?
 
-Rename `env.example` to `immich.env`. Populate the values as needed.
+Create a podman secret for the database password:
+
+```
+openssl rand -base64 20 | podman secret create immich-db-password -
+```
+
+Populate values in `immich.env` as needed.
 
 ## Volume setup
 

--- a/immich-database.container
+++ b/immich-database.container
@@ -3,6 +3,7 @@ Pod=immich.pod
 ContainerName=immich_postgres
 Environment="POSTGRES_INITDB_ARGS=--data-checksums"
 EnvironmentFile=immich.env
+Secret=immich-db-password,type=env,target=POSTGRES_PASSWORD
 Image=ghcr.io/immich-app/postgres:14-vectorchord0.4.3-pgvectors0.2.0@sha256:bcf63357191b76a916ae5eb93464d65c07511da41e3bf7a8416db519b40b1c23
 Volume=./immich-database-healthcheck:/health.sh:z
 ShmSize=128m

--- a/immich-server.container
+++ b/immich-server.container
@@ -6,6 +6,7 @@ After=immich-redis.service immich-database.service
 Pod=immich.pod
 ContainerName=immich_server
 EnvironmentFile=immich.env
+Secret=immich-db-password,type=env,target=DB_PASSWORD
 
 Image=immich-server.image
 

--- a/immich.env
+++ b/immich.env
@@ -1,10 +1,5 @@
 # You can find documentation for all the supported env variables at https://immich.app/docs/install/environment-variables
 
-# Connection secret for postgres. You should change it to a random password. 
-# The two values should match
-DB_PASSWORD=postgres
-POSTGRES_PASSWORD=postgres
-
 # if your database isn't stored on SSDs
 #DB_STORAGE_TYPE=HDD
 


### PR DESCRIPTION
Podman secrets can be created and mounted with different targets. This provides a more secure storage and avoids the need to keep it in sync manually.

The README is updated with an example command that encourages the most secure way: a random password.