### PR TITLE
Change update-images schedule to run daily

### DIFF
--- a/.github/workflows/update-images.yml
+++ b/.github/workflows/update-images.yml
@@ -8,8 +8,8 @@ on:
         required: false
         type: string
   schedule:
-    # Run every Monday at 9:00 AM UTC
-    - cron: '0 9 * * 1'
+    # Run everyday at 9:00 AM UTC
+    - cron: '0 9 * * *'
 
 jobs:
   update-images:


### PR DESCRIPTION
Immich might release bugfixes in quick succession after a major release. It would be nice to be able to have these changes as quick as possible as well. For example. 2.5.3 was released today. We would now have to wait until Monday otherwise. 